### PR TITLE
docs: 将开发文档从README迁移到DEVELOPMENT文件

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,42 @@
+## 开发
+
+### 环境要求
+
+- Node.js >= 18
+- pnpm >= 8
+
+### 开发命令
+
+```bash
+# 安装依赖
+pnpm install
+
+# 构建所有
+pnpm run build:prepare
+
+# 编译扩展
+pnpm run compile
+
+# 监听模式（开发）
+pnpm run watch
+
+# 打包扩展
+pnpm run vsce
+
+# 运行 Linter
+pnpm run lint
+```
+
+## 项目结构
+
+```
+vscode-ext-code-assist/
+├── packages/
+│   ├── main/                    # VS Code 扩展主程序
+│   ├── vscode-webview-rpc/      # Webview RPC 通信库
+│   └── webview/                 # Vue 3 前端界面
+```
+
+## 技术栈
+
+- TypeScript, VS Code Extension API, Vue 3, Vite, Webpack, pnpm, DeepSeek API

--- a/README.md
+++ b/README.md
@@ -36,49 +36,6 @@ code --install-extension code-assist-*.vsix
 
 通过 `Ctrl+Shift+P` / `Cmd+Shift+P` 访问所有 `Code Assist:` 开头的命令。
 
-## 开发
-
-### 环境要求
-
-- Node.js >= 18
-- pnpm >= 8
-
-### 开发命令
-
-```bash
-# 安装依赖
-pnpm install
-
-# 构建所有
-pnpm run build:prepare
-
-# 编译扩展
-pnpm run compile
-
-# 监听模式（开发）
-pnpm run watch
-
-# 打包扩展
-pnpm run vsce
-
-# 运行 Linter
-pnpm run lint
-```
-
-## 项目结构
-
-```
-vscode-ext-code-assist/
-├── packages/
-│   ├── main/                    # VS Code 扩展主程序
-│   ├── vscode-webview-rpc/      # Webview RPC 通信库
-│   └── webview/                 # Vue 3 前端界面
-```
-
-## 技术栈
-
-- TypeScript, VS Code Extension API, Vue 3, Vite, Webpack, pnpm, DeepSeek API
-
 ## 许可证
 
 MIT License


### PR DESCRIPTION
将开发环境要求、命令、项目结构和技术栈等内容从README.md迁移到新创建的DEVELOPMENT.md文件，保持README专注于用户使用说明